### PR TITLE
Unlike into and onto, ‘upto’ isn't a single word.

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -8,7 +8,7 @@
         "description": "text for browser action"
     },
     "storageText": {
-        "message": "Can store data upto 5 MB",
+        "message": "Can store data up to 5 MB",
         "description": "Description of the storage text"
     },
     "geoLocationText": {


### PR DESCRIPTION
Small English typo fix.